### PR TITLE
Enable Github CI (Windows x64 only)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+name: Build and Release
+
+on: [push, pull_request]
+
+concurrency:
+  group: ci-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+    get-info:
+        runs-on: ubuntu-24.04
+        outputs:
+          date: ${{ steps.vars.outputs.date }}
+          shorthash: ${{ steps.vars.outputs.shorthash }}
+          fullhash: ${{ steps.vars.outputs.fullhash }}
+        steps:
+        - uses: actions/checkout@v4
+        - name: Get date and git hash
+          id: vars
+          run: |
+            echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+            echo "shorthash=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+            echo "fullhash=$(git rev-parse HEAD)" >> $GITHUB_ENV
+            echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+            echo "shorthash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+            echo "fullhash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+    windows:
+        runs-on: windows-2025
+        needs: get-info
+        steps:
+        - uses: actions/checkout@v4
+          with:
+            submodules: recursive
+            
+        - name: Setup VS Environment
+          uses: ilammy/msvc-dev-cmd@v1.13.0
+          with:
+            arch: amd64
+
+        - name: Build
+          run: dotnet build --configuration Release --output ${{github.workspace}}/build
+
+        - name: Upload Windows artifact
+          uses: actions/upload-artifact@v4
+          with:
+            name: Warbox-win64-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}
+            path: ${{github.workspace}}/build
+        


### PR DESCRIPTION
Enable Github CI for automated builds in the Actions tab.

- on: push, pull_request
- Windows x64 release build only

Name of the artifact is Warbox-win64-date-hash
example:  `Warbox-win64-2025-02-09-e1eae13 `

There is no cache or logic to make automatic releases